### PR TITLE
fix panic of blocks_mined in accounting.rs

### DIFF
--- a/src/accounting.rs
+++ b/src/accounting.rs
@@ -229,7 +229,7 @@ impl Accounting {
 
     pub async fn blocks_mined(&self, recent: bool, limit: Option<u32>) -> Result<serde_json::Value> {
         let client = reqwest::Client::new();
-        let latest_block_height: u32 = client
+        let latest_block_height = client
             .post(format!("http://{}:3032", self.operator))
             .json(&json!({
                 "jsonrpc": "2.0",
@@ -242,7 +242,7 @@ impl Accounting {
             .json::<serde_json::Value>()
             .await?["result"]
             .as_u64()
-            .ok_or(anyhow!("Unable to get latest block height"))? as u32;
+            .ok_or(anyhow!("Unable to get latest block height"))? as i32;
         let mut obj = serde_json::Map::new();
         let jsonrpc = json!({
             "jsonrpc": "2.0",
@@ -275,11 +275,12 @@ impl Accounting {
                     .await?;
                 let (provers, shares) = Accounting::pplns_to_provers_shares(&v);
                 let canonical = result["result"]["canonical"].as_bool().ok_or(anyhow!("canonical"))?;
+                let compare_res = latest_block_height - Testnet2::ALEO_MAXIMUM_FORK_DEPTH as i32 >= height as i32;
                 blocks.push(json!({
                     "height": height,
                     "block_hash": block_hash.to_string(),
                     "confirmed": if canonical {
-                        latest_block_height - Testnet2::ALEO_MAXIMUM_FORK_DEPTH >= height
+                        compare_res
                     } else {
                         false
                     },


### PR DESCRIPTION
latest_block_height - Testnet2::ALEO_MAXIMUM_FORK_DEPTH >= height will panic when the result of (latest_block_height - Testnet2::ALEO_MAXIMUM_FORK_DEPTH) < 0,